### PR TITLE
mdss: livedisplay: Fix memory leaks in mdss_livedisplay_update()

### DIFF
--- a/drivers/video/msm/mdss/mdss_livedisplay.c
+++ b/drivers/video/msm/mdss/mdss_livedisplay.c
@@ -261,6 +261,8 @@ int mdss_livedisplay_update(struct mdss_dsi_ctrl_pdata *ctrl_pdata,
 	if (ret == 0) {
 		mdss_dsi_panel_cmds_send(ctrl_pdata, &dsi_cmds,
 				CMD_REQ_COMMIT | CMD_CLK_CTRL);
+		kfree(dsi_cmds.buf);
+		kfree(dsi_cmds.cmds);
 	} else {
 		pr_err("%s: error parsing DSI command! ret=%d", __func__, ret);
 	}


### PR DESCRIPTION
parse_dsi_cmds() allocates two blocks of memory and stores their addresses
in a stack-allocated variable, but they are never freed, so when the
function exits, all references to them are gone.

Free the allocated memory after using it in order to fix the memory leaks.

Change-Id: Ie574848e2429167fc38ed39975feb3df68ed2aed
Signed-off-by: Sultanxda <sultanxda@gmail.com>